### PR TITLE
Feature/persistence impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ gradle-app.setting
 
 kotlin-js-store
 *.hprof
+
+# Env
+.env

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
   implementation("org.springframework.boot:spring-boot-starter-actuator")
   implementation("org.springframework.kafka:spring-kafka")
-  implementation("io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE")
+  implementation("org.postgresql:r2dbc-postgresql:1.0.1.RELEASE")
   implementation("org.jetbrains.kotlin:kotlin-stdlib")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
   implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,8 @@ dependencies {
 
   implementation(libs.kotlinx.datetime)
 
+  runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.89.Final:osx-aarch_64")
+
 
   testImplementation(libs.testcontainers.postgresql)
   testImplementation(libs.testcontainers.kafka)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
   alias(libs.plugins.kotest.multiplatform)
   alias(libs.plugins.kover)
   id(libs.plugins.detekt.pluginId)
-  id("org.springframework.boot") version "3.0.3"
+  id("org.springframework.boot") version "3.0.4"
   id("io.spring.dependency-management") version "1.1.0"
   kotlin("jvm")
   kotlin("plugin.spring") version "1.7.22"
@@ -103,9 +103,6 @@ dependencies {
 
   runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.89.Final:osx-aarch_64")
 
-
-  testImplementation(libs.testcontainers.postgresql)
-  testImplementation(libs.testcontainers.kafka)
   testImplementation(libs.bundles.kotest)
   testImplementation("org.springframework.boot:spring-boot-starter-test:3.0.0")
 }

--- a/buildSrc/src/main/kotlin/predef.kt
+++ b/buildSrc/src/main/kotlin/predef.kt
@@ -1,5 +1,5 @@
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
-import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.Provider
 import org.gradle.plugin.use.PluginDependency
 import org.gradle.api.provider.Property
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-arrow = "1.1.3"
+arrow = "1.1.5"
 suspendapp = "0.3.1"
 arrowGradleConfig = "0.10.1"
 coroutines = "1.6.4"
@@ -8,15 +8,16 @@ kotest = "5.5.4"
 kotest-plugin = "5.5.4"
 kover = "0.6.1"
 detekt = "1.22.0"
-ktor = "2.1.3"
 logback = "1.4.5"
 sqldelight = "2.0.0-alpha04"
 testcontainers = "1.17.6"
 hikari = "5.0.1"
-postgresql = "42.5.1"
+postgresql = "42.5.4"
 kotest-arrow = "1.3.0"
 kotest-arrow-fx = "1.3.0"
-flyway = "9.8.3"
+kotest-spring = "1.1.2"
+kotest-testcontainers = "1.3.4"
+flyway = "9.12.0"
 kotlin-logging = "3.0.4"
 avro4k = "1.6.0"
 kotlin-kafka = "0.3.0"
@@ -39,25 +40,11 @@ kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest"
 kotest-runnerJUnit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-arrow = { module = "io.kotest.extensions:kotest-assertions-arrow", version.ref = "kotest-arrow" }
 kotest-arrow-fx = { module = "io.kotest.extensions:kotest-assertions-arrow-fx-coroutines", version.ref = "kotest-arrow-fx" }
-ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
-ktor-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
-ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
-ktor-server-defaultheaders = { module = "io.ktor:ktor-server-default-headers", version.ref = "ktor" }
-ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
-ktor-server-tests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor" }
-ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
-ktor-server-micrometer = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref = "ktor" }
-ktor-server-resources = { module = "io.ktor:ktor-server-resources", version.ref = "ktor" }
-ktor-client = { module = "io.ktor:ktor-client-apache", version.ref = "ktor" }
-ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
-ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
-ktor-client-resources = { module = "io.ktor:ktor-client-resources", version.ref = "ktor" }
+kotest-testcontainers = { module = "io.kotest.extensions:kotest-extensions-testcontainers", version.ref = "kotest-testcontainers" }
+kotest-spring = { module = "io.kotest.extensions:kotest-extensions-spring", version.ref = "kotest-spring" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
-testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
-testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainers" }
 hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 sqldelight-jdbc = { module = "app.cash.sqldelight:jdbc-driver", version.ref = "sqldelight" }
 sqldelight-postgresql = { module = "app.cash.sqldelight:postgresql-dialect", version.ref = "sqldelight" }
@@ -72,35 +59,18 @@ kafka-schema-registry = { module = "io.confluent:kafka-schema-registry-client", 
 kafka-avro-serializer = { module = "io.confluent:kafka-avro-serializer", version.ref = "kafka" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 micrometer-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "prometheus" }
-tegral-openApi-ktor = { module = "guru.zoroark.tegral:tegral-openapi-ktor", version.ref = "tegralOpenApi" }
-tegral-openApi-ktor-ui = { module = "guru.zoroark.tegral:tegral-openapi-ktorui", version.ref = "tegralOpenApi" }
 
 [bundles]
 arrow = ["arrow-core", "arrow-fx"]
-ktor-client = [
-    "ktor-client",
-    "ktor-client-content-negotiation",
-    "ktor-client-serialization",
-    "ktor-client-resources"
-]
-ktor-server = [
-    "ktor-server-core",
-    "ktor-server-cors",
-    "ktor-server-defaultheaders",
-    "ktor-server-content-negotiation",
-    "ktor-serialization",
-    "ktor-server-netty",
-    "ktor-server-auth",
-    "ktor-server-micrometer",
-    "ktor-server-resources"
-]
 kotest = [
     "kotest-assertionsCore",
     "kotest-frameworkEngine",
     "kotest-property",
     "kotest-runnerJUnit5",
     "kotest-arrow",
-    "kotest-arrow-fx"
+    "kotest-arrow-fx",
+    "kotest-spring",
+    "kotest-testcontainers"
 ]
 
 [plugins]
@@ -110,4 +80,3 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
-ktor = { id = "io.ktor.plugin", version.ref = "ktor" }

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-arrow = "1.1.5"
+arrow = "2.0.0-SNAPSHOT"
 suspendapp = "0.3.1"
 arrowGradleConfig = "0.10.1"
 coroutines = "1.6.4"
@@ -29,6 +29,7 @@ tegralOpenApi = "0.0.3"
 [libraries]
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrow-fx = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow" }
+arrow-fx-resilience = { module = "io.arrow-kt:arrow-fx-resilience", version.ref = "arrow" }
 suspendapp = { module = "io.arrow-kt:suspendapp", version.ref = "suspendapp" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
@@ -56,7 +57,7 @@ avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 micrometer-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "prometheus" }
 
 [bundles]
-arrow = ["arrow-core", "arrow-fx"]
+arrow = ["arrow-core", "arrow-fx", "arrow-fx-resilience"]
 kotest = [
     "kotest-assertionsCore",
     "kotest-frameworkEngine",

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -9,9 +9,7 @@ kotest-plugin = "5.5.4"
 kover = "0.6.1"
 detekt = "1.22.0"
 logback = "1.4.5"
-sqldelight = "2.0.0-alpha04"
 testcontainers = "1.17.6"
-hikari = "5.0.1"
 postgresql = "42.5.4"
 kotest-arrow = "1.3.0"
 kotest-arrow-fx = "1.3.0"
@@ -45,9 +43,6 @@ kotest-spring = { module = "io.kotest.extensions:kotest-extensions-spring", vers
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
-hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
-sqldelight-jdbc = { module = "app.cash.sqldelight:jdbc-driver", version.ref = "sqldelight" }
-sqldelight-postgresql = { module = "app.cash.sqldelight:postgresql-dialect", version.ref = "sqldelight" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 flyway = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 klogging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin-logging" }
@@ -79,4 +74,3 @@ kotest-multiplatform = { id = "io.kotest.multiplatform", version.ref = "kotest-p
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }

--- a/src/main/kotlin/alerts/env/Config.kt
+++ b/src/main/kotlin/alerts/env/Config.kt
@@ -21,10 +21,13 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories
 import org.springframework.kafka.config.TopicBuilder
 import org.springframework.kafka.core.KafkaAdmin
 import org.springframework.kafka.core.reactive.ReactiveKafkaConsumerTemplate
 import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate
+import org.springframework.r2dbc.connection.R2dbcTransactionManager
+import org.springframework.transaction.reactive.TransactionalOperator
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.kafka.receiver.ReceiverOptions
 import reactor.kafka.sender.SenderOptions

--- a/src/main/kotlin/alerts/env/Config.kt
+++ b/src/main/kotlin/alerts/env/Config.kt
@@ -21,13 +21,10 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories
 import org.springframework.kafka.config.TopicBuilder
 import org.springframework.kafka.core.KafkaAdmin
 import org.springframework.kafka.core.reactive.ReactiveKafkaConsumerTemplate
 import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate
-import org.springframework.r2dbc.connection.R2dbcTransactionManager
-import org.springframework.transaction.reactive.TransactionalOperator
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.kafka.receiver.ReceiverOptions
 import reactor.kafka.sender.SenderOptions

--- a/src/main/kotlin/alerts/kafka/AvroSerializer.kt
+++ b/src/main/kotlin/alerts/kafka/AvroSerializer.kt
@@ -2,7 +2,6 @@ package alerts.kafka
 
 import com.github.avrokotlin.avro4k.Avro
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serializer
 

--- a/src/main/kotlin/alerts/notification/service.kt
+++ b/src/main/kotlin/alerts/notification/service.kt
@@ -6,10 +6,10 @@ import alerts.github.SlackNotification
 import alerts.subscription.Repository
 import alerts.subscription.SubscriptionsPersistence
 import alerts.user.UserPersistence
-import alerts.catch
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.catch
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
 import arrow.optics.Optional
 import io.github.nomisrev.JsonPath
 import io.github.nomisrev.path
@@ -49,8 +49,8 @@ class Notifications(
   ): Either<NotificationError, Repository> =
     either {
       val json = catch({ Json.parseToJsonElement(event.event) }) { error: SerializationException ->
-        MalformedJson(event.event, error)
-      }.bind()
+        raise(MalformedJson(event.event, error))
+      }
       val fullName = ensureNotNull(fullNamePath.getOrNull(json)) { RepoFullNameNotFound(json) }
       val (owner, name) = ensureNotNull(fullName.split("/").takeIf { it.size == 2 }) { CannotExtractRepo(fullName) }
       Repository(owner, name)

--- a/src/main/kotlin/alerts/predef.kt
+++ b/src/main/kotlin/alerts/predef.kt
@@ -1,9 +1,5 @@
 package alerts
 
-import arrow.core.Either
-import arrow.core.left
-import arrow.core.nonFatalOrThrow
-import arrow.core.right
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
@@ -14,24 +10,6 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.encoding.encodeStructure
 import org.springframework.http.HttpStatusCode
-
-/**
- * Catches a [Throwable], and allows mapping to [E].
- * In the case `null` is returned the original [Throwable] is rethrown,
- * otherwise `Either<E, A>` is returned.
- */
-@Suppress("TooGenericExceptionCaught")
-inline fun <reified T : Throwable, E, A> catch(
-  block: () -> A,
-  transform: (T) -> E,
-): Either<E, A> = try {
-  block().right()
-} catch (e: Throwable) {
-  val nonFatal = e.nonFatalOrThrow()
-  if (nonFatal is T) {
-    transform(nonFatal).left()
-  } else throw e
-}
 
 object HttpStatusCodeSerializer : KSerializer<HttpStatusCode> {
   override val descriptor: SerialDescriptor = buildClassSerialDescriptor("HttpStatusCode") {

--- a/src/main/kotlin/alerts/subscription/SubscriptionController.kt
+++ b/src/main/kotlin/alerts/subscription/SubscriptionController.kt
@@ -1,8 +1,8 @@
 package alerts.subscription
 
 import alerts.user.SlackUserId
-import arrow.core.continuations.either
 import arrow.core.merge
+import arrow.core.raise.either
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime

--- a/src/main/kotlin/alerts/subscription/persistence.kt
+++ b/src/main/kotlin/alerts/subscription/persistence.kt
@@ -1,65 +1,124 @@
 package alerts.subscription
 
+import alerts.catch
 import alerts.user.UserId
 import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import arrow.core.traverse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toJavaLocalDateTime
+import org.postgresql.util.PSQLException
+import org.postgresql.util.PSQLState
 import org.springframework.data.annotation.Id
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.relational.core.mapping.Table
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Table(value = "subscriptions")
-data class SubscriptionDto(
-  @Id val id: Long,
-  val userId: UserId,
-  val repository: Repository,
-  val createdAt: LocalDateTime
+data class SubscriptionDTO(
+    @Id val id: Long,
+    val owner: String,
+    val repository: Repository,
+    val subscribedAt: LocalDateTime
 )
 
-interface SubscriptionRepo : CoroutineCrudRepository<SubscriptionDto, Long> {
-  fun findAllByRepository(repository: Repository): Flow<SubscriptionDto>
+@Table(value = "repositories")
+data class RepositoryDTO(
+  @Id val id: Long,
+  val owner: String,
+  val repository: String
+)
+
+interface SubscriptionRepo : CoroutineCrudRepository<SubscriptionDTO, Long> {
+    @Query("""
+      SELECT repositories.owner,
+             repositories.repository,
+             subscriptions.subscribed_at
+      FROM repositories
+      INNER JOIN subscriptions ON subscriptions.repository_id = repositories.repository_id
+      WHERE subscriptions.user_id = :userId;
+    """)
+    fun findAllByUserId(userId: Long): Flow<SubscriptionDTO>
+
+    @Query("""
+      SELECT subscriptions.user_id
+      FROM subscriptions
+      INNER JOIN repositories ON subscriptions.repository_id = repositories.repository_id
+      WHERE repositories.owner = :repositoryOwner
+      AND   repositories.repository = :repositoryName;
+    """)
+    fun findAllSubscribers(repositoryOwner: String, repositoryName: String): Flow<UserId>
+
+  @Query("""
+    INSERT INTO subscriptions (user_id, repository_id, subscribed_at)
+    VALUES (:userId, :repositoryId, :subscribedAt)
+    ON CONFLICT DO NOTHING;
+    """)
+    suspend fun insert(userId: Long, repositoryId: Long, subscribedAt: LocalDateTime)
+}
+
+interface RepositoryRepo : CoroutineCrudRepository<RepositoryDTO, Long> {
+  @Query("""
+    INSERT INTO repositories(owner, repository)
+    VALUES (:repositoryOwner, :repositoryName)
+    ON CONFLICT DO NOTHING
+    RETURNING repository_id;
+  """)
+  suspend fun insert(repositoryOwner: String, repositoryName: String): RepositoryId
 }
 
 interface SubscriptionsPersistence {
-  suspend fun findAll(user: UserId): List<Subscription>
-  suspend fun findSubscribers(repository: Repository): List<UserId>
-  suspend fun subscribe(user: UserId, subscription: List<Subscription>): Either<UserNotFound, Unit>
-  suspend fun unsubscribe(user: UserId, repositories: List<Repository>): Unit
+    suspend fun findAll(user: UserId): List<Subscription>
+    suspend fun findSubscribers(repository: Repository): List<UserId>
+    suspend fun subscribe(user: UserId, subscription: List<Subscription>): Either<UserNotFound, Unit>
+    suspend fun unsubscribe(user: UserId, repositories: List<Repository>): Unit
 
-  suspend fun subscribe(user: UserId, subscription: Subscription): Either<UserNotFound, Unit> =
-    subscribe(user, listOf(subscription))
+    suspend fun subscribe(user: UserId, subscription: Subscription): Either<UserNotFound, Unit> =
+        subscribe(user, listOf(subscription))
 
-  suspend fun unsubscribe(user: UserId, repositories: Repository): Unit =
-    unsubscribe(user, listOf(repositories))
+    suspend fun unsubscribe(user: UserId, repositories: Repository): Unit =
+        unsubscribe(user, listOf(repositories))
 }
 
 @Component
 class DefaultSubscriptionsPersistence(
-  private val repo: SubscriptionRepo
-): SubscriptionsPersistence {
-  override suspend fun findAll(user: UserId): List<Subscription> =
-    repo.findAllById(listOf(user.serial)).map { subscription ->
-      Subscription(subscription.repository, subscription.createdAt)
-    }.toList()
+    private val subscriptions: SubscriptionRepo,
+    private val repositories: RepositoryRepo
+) : SubscriptionsPersistence {
+    override suspend fun findAll(user: UserId): List<Subscription> =
+      subscriptions.findAllByUserId(user.serial).map { subscription ->
+            Subscription(subscription.repository, subscription.subscribedAt)
+        }.toList()
 
-  override suspend fun findSubscribers(repository: Repository): List<UserId> =
-    repo.findAllByRepository(repository).map { subscription ->
-      UserId(subscription.id)
-    }.toList()
+    override suspend fun findSubscribers(repository: Repository): List<UserId> =
+      subscriptions.findAllSubscribers(repository.owner, repository.name).toList()
 
-  override suspend fun subscribe(user: UserId, subscription: List<Subscription>): Either<UserNotFound, Unit> {
-    TODO("Not yet implemented")
-//    subscription.traverse { (repository, subscribedAt) ->
-//      val repoId = repo.save(Repository(repository.owner, repository.name))
-//    }
-  }
+    @Transactional
+    override suspend fun subscribe(user: UserId, subscription: List<Subscription>): Either<UserNotFound, Unit> =
+      subscription.traverse { (repository, subscribedAt) ->
+        val repoId = repositories.insert(repository.owner, repository.name)
 
-  override suspend fun unsubscribe(user: UserId, repositories: List<Repository>) {
-    TODO("Not yet implemented")
-  }
+        catch({
+          subscriptions.insert(user.serial, repoId.serial, subscribedAt)
+        }) { error: PSQLException ->
+          if (error.isUserIdForeignKeyViolation()) UserNotFound(user)
+          else throw error
+        }
+      }.fold({ it.left() }, { Unit.right() })
+
+
+    @Transactional
+    override suspend fun unsubscribe(user: UserId, repositories: List<Repository>) {
+        TODO("Not yet implemented")
+    }
+
+    fun PSQLException.isUserIdForeignKeyViolation(): Boolean =
+      sqlState == PSQLState.FOREIGN_KEY_VIOLATION.state && message?.contains("subscriptions_user_id_fkey") == true
 
 }

--- a/src/main/kotlin/alerts/subscription/producer.kt
+++ b/src/main/kotlin/alerts/subscription/producer.kt
@@ -1,6 +1,5 @@
 package alerts.subscription
 
-import alerts.env.Kafka
 import alerts.env.SubscriptionTopic
 import kotlinx.coroutines.reactive.awaitSingle
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -15,7 +14,6 @@ interface SubscriptionProducer {
 @Component
 class DefaultSubscriptionProducer(
   private val producer: ReactiveKafkaProducerTemplate<SubscriptionKey, SubscriptionEventRecord>,
-  private val kafka: Kafka,
   private val topic: SubscriptionTopic,
 ) : SubscriptionProducer {
   override suspend fun publish(repo: Repository) {

--- a/src/main/kotlin/alerts/subscription/service.kt
+++ b/src/main/kotlin/alerts/subscription/service.kt
@@ -4,8 +4,9 @@ import alerts.github.GithubClient
 import alerts.user.SlackUserId
 import alerts.user.UserPersistence
 import arrow.core.Either
-import arrow.core.continuations.either
-import arrow.core.continuations.ensureNotNull
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 

--- a/src/main/kotlin/alerts/subscription/service.kt
+++ b/src/main/kotlin/alerts/subscription/service.kt
@@ -7,7 +7,7 @@ import arrow.core.Either
 import arrow.core.continuations.either
 import arrow.core.continuations.ensureNotNull
 import mu.KotlinLogging
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 
 interface SubscriptionService {
   /** Returns all subscriptions for the given [slackUserId], empty if none found */
@@ -26,8 +26,8 @@ interface SubscriptionService {
   suspend fun unsubscribe(slackUserId: SlackUserId, repository: Repository): Either<SlackUserNotFound, Unit>
 }
 
-@Component
-class SqlDelightSubscriptionService(
+@Service
+class SpringSubscriptionService(
   private val subscriptions: SubscriptionsPersistence,
   private val users: UserPersistence,
   private val producer: SubscriptionProducer,

--- a/src/main/kotlin/alerts/user/persistence.kt
+++ b/src/main/kotlin/alerts/user/persistence.kt
@@ -58,9 +58,10 @@ class DefaultUserPersistence(
 
   override suspend fun insertSlackUser(slackUserId: SlackUserId): User =
     transactionOperator.executeAndAwait {
-      (queries.findBySlackUserId(slackUserId.slackUserId) ?:
+      val dto = queries.findBySlackUserId(slackUserId.slackUserId) ?:
         UserDTO(queries.insertSlackUserId(slackUserId.slackUserId), slackUserId.slackUserId)
           .also { slackUsersCounter.inc() }
-      ).let { User(UserId(it.userId), SlackUserId(it.slackUserId)) }
+       User(UserId(dto.userId), SlackUserId(dto.slackUserId)
+      )
     }
 }

--- a/src/main/kotlin/alerts/user/persistence.kt
+++ b/src/main/kotlin/alerts/user/persistence.kt
@@ -7,21 +7,23 @@ import kotlinx.coroutines.flow.toList
 import org.springframework.data.annotation.Id
 import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Component
 
-data class UserDto(
+@Table(name = "users")
+data class UserDTO(
   @Id
   @Column("userId")
   val userId: Long,
   val slackUserId: String
 )
 
-interface UserRepo : CoroutineCrudRepository<UserDto, Long> {
-  suspend fun findBySlackUserId(slackUserId: String): UserDto?
+interface UserRepo : CoroutineCrudRepository<UserDTO, Long> {
+  suspend fun findBySlackUserId(slackUserId: String): UserDTO?
 
   @Query("INSERT INTO users(slack_user_id) VALUES (:slackUserId) RETURNING user_id")
-  suspend fun insertSlackUserId(slackUserId: String): UserDto
+  suspend fun insertSlackUserId(slackUserId: String): UserDTO
 }
 
 interface UserPersistence {

--- a/src/main/kotlin/alerts/user/persistence.kt
+++ b/src/main/kotlin/alerts/user/persistence.kt
@@ -61,5 +61,5 @@ class DefaultUserPersistence(
       (queries.findBySlackUserId(slackUserId.slackUserId) ?: queries.insertSlackUserId(slackUserId.slackUserId))
         .let { User(UserId(it.userId), SlackUserId(it.slackUserId)) }
         .also { slackUsersCounter.inc() }
-    }!!
+    } ?: error("Failed to insert slack user")
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,9 +36,11 @@ spring:
     url: ${POSTGRES_R2DBC_URL:r2dbc:postgresql://localhost:5432/alerts}
     username: ${POSTGRES_USER:test}
     password: ${POSTGRES_USER:test}
+    properties:
+      schema: subscriptions
   flyway:
     url: ${POSTGRES_JDBC_URL:jdbc:postgresql://localhost:5432/alerts}
-    schemas: SUBSCRIPTIONSSERVICE
+    schemas: subscriptions
     user: ${POSTGRES_USER:test}
     password: ${POSTGRES_USER:test}
 

--- a/src/test/kotlin/alerts/ComposeContainer.kt
+++ b/src/test/kotlin/alerts/ComposeContainer.kt
@@ -1,0 +1,41 @@
+package alerts
+
+import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy
+import org.testcontainers.containers.wait.strategy.WaitStrategy
+import java.io.File
+
+sealed class Service {
+    abstract val name: String
+    abstract val port: Int
+    abstract val waitStrategy: WaitStrategy
+
+    companion object {
+        val defaultWaitStrategy: WaitAllStrategy = WaitAllStrategy(WaitAllStrategy.Mode.WITH_INDIVIDUAL_TIMEOUTS_ONLY)
+            .apply { withStrategy(Wait.forListeningPort()) }
+    }
+
+    class Postgres : Service() {
+        override val name: String = "postgres"
+        override val port: Int = 5432
+        override val waitStrategy: WaitStrategy = defaultWaitStrategy
+            .apply {
+                withStrategy(
+                    Wait.forLogMessage(".*database system is ready to accept connections.*", 1)
+                )
+            }
+    }
+}
+
+class ComposeContainer(
+    composeFiles: List<File>
+) : DockerComposeContainer<ComposeContainer>(composeFiles) {
+    companion object {
+        fun container(
+            composeFiles: List<File>, services: List<Service>
+        ): ComposeContainer =
+            ComposeContainer(composeFiles)
+                .apply { services.forEach { withExposedService(it.name, it.port, it.waitStrategy) } }
+    }
+}

--- a/src/test/kotlin/alerts/IntegrationTestBase.kt
+++ b/src/test/kotlin/alerts/IntegrationTestBase.kt
@@ -1,0 +1,26 @@
+package alerts
+
+import io.kotest.core.extensions.Extension
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.spring.SpringExtension
+import org.springframework.boot.test.context.SpringBootTest
+import java.io.File
+
+@SpringBootTest
+class IntegrationTestBase(body: StringSpec.() -> Unit = {}) : StringSpec(body) {
+    override fun extensions(): List<Extension> = listOf(SpringExtension)
+
+    override suspend fun afterSpec(spec: Spec) {
+        container.stop()
+        super.afterSpec(spec)
+    }
+
+    companion object {
+        internal val container =
+            ComposeContainer.container(
+                listOf(File("docker-compose.yml"), File("docker-compose.local.yml")),
+                listOf(Service.Postgres())
+            ).also { it.start() }
+    }
+}

--- a/src/test/kotlin/alerts/TestMetrics.kt
+++ b/src/test/kotlin/alerts/TestMetrics.kt
@@ -1,0 +1,12 @@
+package alerts
+
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.Counter
+
+object TestMetrics {
+  val slackUsersCounter: Counter =
+    Counter.build()
+      .name("slack_users_counter")
+      .help("Number of Slack users registered with our service")
+      .register(CollectorRegistry.defaultRegistry)
+}

--- a/src/test/kotlin/alerts/persistence/SubscriptionPersistenceSpec.kt
+++ b/src/test/kotlin/alerts/persistence/SubscriptionPersistenceSpec.kt
@@ -1,0 +1,130 @@
+package alerts.persistence
+
+import alerts.IntegrationTestBase
+import alerts.TestMetrics
+import alerts.subscription.DefaultSubscriptionsPersistence
+import alerts.subscription.Repository
+import alerts.subscription.RepositoryRepo
+import alerts.subscription.SubscriptionRepo
+import alerts.subscription.Subscription
+import alerts.subscription.UserNotFound
+import alerts.user.DefaultUserPersistence
+import alerts.user.SlackUserId
+import alerts.user.UserId
+import alerts.user.UserRepo
+import alerts.user.User
+import io.kotest.assertions.arrow.core.shouldBeLeft
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.springframework.transaction.reactive.TransactionalOperator
+
+class SubscriptionPersistenceSpec(
+    userRepo: UserRepo,
+    subscriptionRepo: SubscriptionRepo,
+    repositoryRepo: RepositoryRepo,
+    transactionOperator: TransactionalOperator
+) : IntegrationTestBase({
+
+    val arrow = Repository("Arrow-kt", "arrow")
+    val arrowAnalysis = Repository("Arrow-kt", "arrow-analysis")
+    val persistence = DefaultSubscriptionsPersistence(subscriptionRepo, repositoryRepo, transactionOperator)
+    val users = DefaultUserPersistence(userRepo, TestMetrics.slackUsersCounter, transactionOperator)
+
+    afterTest {
+        userRepo.deleteAll()
+    }
+
+    "subscribing non-existent user to subscription" {
+        val subscriptions = listOf(
+            Subscription(arrow, LocalDateTime.now()),
+            Subscription(arrowAnalysis, LocalDateTime.now())
+        )
+        val userId = UserId(0L)
+        persistence.subscribe(userId, subscriptions).shouldBeLeft(UserNotFound(userId))
+    }
+
+    "subscribing existent user to subscription" {
+        val subscriptions = listOf(
+            Subscription(arrow, LocalDateTime.now()),
+            Subscription(arrowAnalysis, LocalDateTime.now())
+        )
+        val (userId, _) = users.insertSlackUser(SlackUserId("test-user"))
+        persistence.subscribe(userId, subscriptions).shouldBeRight(Unit)
+    }
+
+    "subscribing user to same subscription" {
+        val subscriptions = listOf(
+            Subscription(arrow, LocalDateTime.now()),
+            Subscription(arrow, LocalDateTime.now()),
+        )
+        val (userId, _) = users.insertSlackUser(SlackUserId("test-user"))
+        persistence.subscribe(userId, subscriptions).shouldBeRight(Unit)
+    }
+
+    "subscribing user to same subscription twice" {
+        val subscriptions = listOf(Subscription(arrow, LocalDateTime.now()))
+        val (userId, _) = users.insertSlackUser(SlackUserId("test-user"))
+        persistence.subscribe(userId, subscriptions).shouldBeRight(Unit)
+        persistence.subscribe(userId, subscriptions).shouldBeRight(Unit)
+    }
+
+    "findSubscribers - empty" {
+        persistence.findSubscribers(arrow).shouldBeEmpty()
+    }
+
+    "findSubscribers - multiple" {
+        val ids = (0..10).map { num ->
+            users.insertSlackUser(SlackUserId("test-user-$num"))
+        }
+        ids.forEach { (userId, _) ->
+            persistence.subscribe(userId, listOf(Subscription(arrow, LocalDateTime.now()))).shouldBeRight(Unit)
+        }
+        persistence.findSubscribers(arrow).shouldBe(ids.map(User::userId))
+    }
+
+    "findAll - empty" {
+        persistence.findAll(UserId(0L)).shouldBeEmpty()
+    }
+
+    "findAll - multiple" {
+        val (userId, _) = users.insertSlackUser(SlackUserId("test-user"))
+        val subs = listOf(
+            Subscription(arrow, LocalDateTime.now()),
+            Subscription(arrowAnalysis, LocalDateTime.now())
+        )
+        persistence.subscribe(userId, subs).shouldBeRight(Unit)
+        persistence.findAll(userId).map(Subscription::repository) shouldBe subs.map(Subscription::repository)
+    }
+
+    "unsubscribe - emptyList" {
+        val (userId, _) = users.insertSlackUser(SlackUserId("test-user"))
+        persistence.unsubscribe(userId, emptyList()).shouldBe(Unit)
+    }
+
+    "unsubscribe - non-existent" {
+        val (userId, _) = users.insertSlackUser(SlackUserId("test-user"))
+        persistence.unsubscribe(userId, listOf(Repository("Empty", "empty"))).shouldBe(Unit)
+    }
+
+    "unsubscribe - removes from database" {
+        val (userId, _) = users.insertSlackUser(SlackUserId("test-user"))
+        val subs = listOf(
+            Subscription(arrow, LocalDateTime.now()),
+            Subscription(arrowAnalysis, LocalDateTime.now())
+        )
+        with(persistence) {
+            subscribe(userId, subs).shouldBeRight(Unit)
+            findAll(userId).map(Subscription::repository) shouldBe subs.map(Subscription::repository)
+            unsubscribe(userId, subs.map { it.repository })
+            findAll(userId).shouldBeEmpty()
+        }
+    }
+})
+
+private fun LocalDateTime.Companion.now(): LocalDateTime =
+    Clock.System.now().toLocalDateTime(TimeZone.UTC)

--- a/src/test/kotlin/alerts/persistence/UserPersistenceSpec.kt
+++ b/src/test/kotlin/alerts/persistence/UserPersistenceSpec.kt
@@ -1,0 +1,94 @@
+package alerts.persistence
+
+import alerts.IntegrationTestBase
+import alerts.TestMetrics
+import alerts.user.*
+import arrow.core.nonEmptyListOf
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.support.beans
+import org.springframework.transaction.reactive.TransactionalOperator
+
+class UserPersistenceSpec(
+    userRepo: UserRepo,
+    transactionOperator: TransactionalOperator
+) : IntegrationTestBase({
+
+    val slackUserId = SlackUserId("test-user-id")
+    val persistence = DefaultUserPersistence(userRepo, TestMetrics.slackUsersCounter, transactionOperator)
+
+    afterTest {
+        userRepo.deleteAll()
+    }
+
+    "Insert user" {
+        persistence.insertSlackUser(slackUserId).slackUserId shouldBe slackUserId
+    }
+
+    "Insert user twice doesn't fails but is idempotent" {
+        val user = persistence.insertSlackUser(slackUserId)
+        persistence.insertSlackUser(slackUserId) shouldBe user
+    }
+
+    "find non-existing user results in null" {
+        persistence.find(UserId(0L)).shouldBeNull()
+    }
+
+    "find existing user" {
+        val user = persistence.insertSlackUser(slackUserId)
+        persistence.find(user.userId).shouldNotBeNull() shouldBe user
+    }
+
+    "findSlackUser non-existing user results in null" {
+        persistence.findSlackUser(SlackUserId("other-user")).shouldBeNull()
+    }
+
+    "findSlackUser existing user" {
+        val user = persistence.insertSlackUser(slackUserId)
+        persistence.findSlackUser(slackUserId).shouldNotBeNull() shouldBe user
+    }
+
+    "findUsers all non-existing is empty" {
+        val ids = nonEmptyListOf(UserId(0L), UserId(1L), UserId(2L))
+        persistence.findUsers(ids).shouldBeEmpty()
+    }
+
+    "findUsers existing users" {
+        val users = nonEmptyListOf(
+            persistence.insertSlackUser(slackUserId),
+            persistence.insertSlackUser(SlackUserId("test-user-id-2")),
+            persistence.insertSlackUser(SlackUserId("test-user-id-3")),
+        )
+        val ids = users.map { it.userId }
+        persistence.findUsers(ids) shouldBe users
+    }
+
+    "Increment counter on new user" {
+        val original = TestMetrics.slackUsersCounter.get()
+        persistence.insertSlackUser(slackUserId)
+        TestMetrics.slackUsersCounter.get() shouldBe original + 1
+    }
+
+    "Doesn't increment counter for existing user" {
+        val original = TestMetrics.slackUsersCounter.get()
+        persistence.insertSlackUser(slackUserId)
+        val now = TestMetrics.slackUsersCounter.get()
+        now shouldBe original + 1
+        persistence.insertSlackUser(slackUserId)
+        TestMetrics.slackUsersCounter.get() shouldBe now
+    }
+})
+
+class KafkaContainer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    override fun initialize(context: ConfigurableApplicationContext) {
+        beans {
+            bean {
+
+            }
+        }
+    }
+}

--- a/src/test/kotlin/alerts/persistence/UserPersistenceSpec.kt
+++ b/src/test/kotlin/alerts/persistence/UserPersistenceSpec.kt
@@ -2,15 +2,15 @@ package alerts.persistence
 
 import alerts.IntegrationTestBase
 import alerts.TestMetrics
-import alerts.user.*
+import alerts.user.DefaultUserPersistence
+import alerts.user.SlackUserId
+import alerts.user.UserId
+import alerts.user.UserRepo
 import arrow.core.nonEmptyListOf
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import org.springframework.context.ApplicationContextInitializer
-import org.springframework.context.ConfigurableApplicationContext
-import org.springframework.context.support.beans
 import org.springframework.transaction.reactive.TransactionalOperator
 
 class UserPersistenceSpec(
@@ -82,13 +82,3 @@ class UserPersistenceSpec(
         TestMetrics.slackUsersCounter.get() shouldBe now
     }
 })
-
-class KafkaContainer : ApplicationContextInitializer<ConfigurableApplicationContext> {
-    override fun initialize(context: ConfigurableApplicationContext) {
-        beans {
-            bean {
-
-            }
-        }
-    }
-}


### PR DESCRIPTION
Changes included:

- Implementation of subscription persistence
- Passing integration tests for subscription and users persistence
- Minor name changes and adding/removing some dependencies

For the integration test part, I was wondering if there is any way of tell **Kotest** to install it as a `ResourceExtension` before the **Spring** context initialization starts. That was my first approach after seeing the examples of `gh-alert-subscriptions-kotlin` and `kstreaming-kotlin`, and digging into `arrow.fx.coroutines.Resource`

However I was not able of make it work that way... any approach I tried to do that ended with Spring trying to connect to the database before the container started. So finally, I did it on a more traditional way.

I appreciate any suggestions on this or any other part of this PR.